### PR TITLE
Improve async shutdown and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .venv
 __pycache__/
+error-log.txt

--- a/Mac_RUNME.command
+++ b/Mac_RUNME.command
@@ -2,5 +2,5 @@
 cd "$(dirname "$0")"
 
 source .venv/bin/activate
-python main.py --log info
+python main.py --log info 2>>error-log.txt
 read

--- a/RUNME.bat
+++ b/RUNME.bat
@@ -3,7 +3,7 @@ setlocal
 cd /d "%~dp0"
 
 call ".venv\Scripts\activate.bat"
-python -u ".\main.py" --log info
+python -u ".\main.py" --log info 2>>error-log.txt
 
 echo Python exited with %errorlevel%
 pause

--- a/Unix_RUNME.sh
+++ b/Unix_RUNME.sh
@@ -1,2 +1,2 @@
 source .venv/bin/activate
-python main.py --log info
+python main.py --log info 2>>error-log.txt

--- a/app/EventHandler/enter_handler.py
+++ b/app/EventHandler/enter_handler.py
@@ -25,7 +25,8 @@ async def handle_enter(event: dict, update_chatbox: bool, update_osc_param: bool
         identity: int = 0
         # logger.debug("Got event %s", str(event))
     except KeyError:
-        logger.warning("进房信息缺失%s", str(event))
+        logger.error("进房信息缺失")
+        logger.debug("进房事件解析失败: %s", event, exc_info=True)
         return
     if update_chatbox:
         if CONFIG['enter']['enter_level'][identity] == 1:

--- a/app/chatbox_consumer.py
+++ b/app/chatbox_consumer.py
@@ -33,6 +33,7 @@ async def chatbox_loop():
             logger.debug("Chatbox loop cancelled")
             raise
         except (IndexError, KeyError, TypeError, ValueError) as e:
-            logger.warning("聊天框请求 %s 发生错误 %s, 忽略并继续", str(request), str(e))
+            logger.error("聊天框请求 %s 发生错误 %s, 忽略并继续", str(request), str(e))
+            logger.debug("聊天框请求解析失败: %s", request, exc_info=True)
         finally:
             chatbox_queue.task_done()

--- a/app/general_consumer.py
+++ b/app/general_consumer.py
@@ -34,6 +34,7 @@ async def general_loop():
             logger.debug("General loop cancelled")
             raise
         except (IndexError, KeyError, TypeError, ValueError) as e:
-            logger.warning("通用请求 %s 发生错误 %s, 忽略并继续", str(request), str(e))
+            logger.error("通用请求 %s 发生错误 %s, 忽略并继续", str(request), str(e))
+            logger.debug("通用请求解析失败: %s", request, exc_info=True)
         finally:
             general_gift_queue.task_done()

--- a/main.py
+++ b/main.py
@@ -10,7 +10,12 @@ Dependencies:
 VRChat is a trademark of VRChat Inc.
 BILIBILI is a trademark of Shanghai Hode Information Technology Co., Ltd.
 """
-import argparse, asyncio, logging, sys
+import argparse
+import asyncio
+import logging
+import signal
+from contextlib import asynccontextmanager, suppress
+import sys
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--log",
@@ -20,9 +25,12 @@ parser.add_argument(
 )
 args = parser.parse_args()
 log_level = getattr(logging, args.log.upper(), logging.WARNING)
+error_handler = logging.FileHandler("error-log.txt", encoding="utf-8")
+error_handler.setLevel(logging.ERROR)
 logging.basicConfig(
     level=log_level,
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    handlers=[logging.StreamHandler(), error_handler],
 )
 from app.Utils.config_loader import CONFIG
 from app.bili_event_dispatch import live_danmaku
@@ -33,35 +41,40 @@ from app.parameter_decay_consumer import parameter_decay_loop
 logger = logging.getLogger(__name__)
 
 
-async def main():
-    """
-    start tasks
-    """
+@asynccontextmanager
+async def bilibili_connection():
+    """Manage LiveDanmaku connection."""
+    task = asyncio.create_task(live_danmaku.connect())
     try:
+        yield
+    finally:
+        task.cancel()
+        with suppress(Exception):
+            await live_danmaku.disconnect()
+
+
+async def main():
+    """Start tasks and handle graceful shutdown."""
+    shutdown_event = asyncio.Event()
+
+    def _handle_shutdown() -> None:
+        logger.info("Received termination signal, shutting down...")
+        shutdown_event.set()
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, _handle_shutdown)
+
+    async with bilibili_connection():
         async with asyncio.TaskGroup() as tg:
-            # 聊天框队列
             tg.create_task(chatbox_loop())
-
-            # 独立动画队列
             tg.create_task(animation_loop())
-
-            # 参数衰退队列
             tg.create_task(parameter_decay_loop())
-
-            # 通用动画队列
             tg.create_task(general_loop())
-
-            # 连接直播间
-            tg.create_task(live_danmaku.connect())
-    except* asyncio.CancelledError:
-        pass
+            await shutdown_event.wait()
+            tg.cancel_scope.cancel()
 
 
 if __name__ == "__main__":
-    try:
-        logger.info("配置： %s", str(CONFIG))
-        asyncio.run(main())
-    except KeyboardInterrupt:
-        sys.exit(130)
-    else:
-        sys.exit(0)
+    logger.info("配置： %s", str(CONFIG))
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- use context manager for LiveDanmaku connection and add SIGINT/SIGTERM shutdown handling
- route error logs to `error-log.txt` and ignore the file in git
- add debug details when events cannot be parsed

## Testing
- `python -m py_compile main.py app/bili_event_dispatch.py app/chatbox_consumer.py app/general_consumer.py app/EventHandler/enter_handler.py`

------
https://chatgpt.com/codex/tasks/task_e_68af4d0344d08325ad44a4bf2a855045