### PR TITLE
Gracefully cancel TaskGroup tasks

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,12 +70,15 @@ async def main():
 
     async with bilibili_connection():
         async with asyncio.TaskGroup() as tg:
-            tg.create_task(chatbox_loop())
-            tg.create_task(animation_loop())
-            tg.create_task(parameter_decay_loop())
-            tg.create_task(general_loop())
+            tasks = [
+                tg.create_task(chatbox_loop()),
+                tg.create_task(animation_loop()),
+                tg.create_task(parameter_decay_loop()),
+                tg.create_task(general_loop()),
+            ]
             await shutdown_event.wait()
-            tg.cancel_scope.cancel()
+            for task in tasks:
+                task.cancel()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure tasks started in the main TaskGroup are cancelled on shutdown

## Testing
- `python main.py --log debug &>/tmp/run.log & PID=$!; sleep 5; kill -INT $PID; wait $PID; tail -n 20 /tmp/run.log`


------
https://chatgpt.com/codex/tasks/task_e_68af5fe2eda88325ab99f9ebe9e63e8d